### PR TITLE
Update Volunteer & Admin Analytics Object

### DIFF
--- a/src/server/db/actions/User.ts
+++ b/src/server/db/actions/User.ts
@@ -14,9 +14,9 @@ async function createUser(
   newUser: IUser,
   session?: ClientSession
 ): Promise<IUser> {
-  if (!newUser.bagelsDelivered) {
-    newUser.bagelsDelivered = 0;
-  }
+  // if (!newUser.bagelsDelivered) {
+  //   newUser.bagelsDelivered = 0;
+  // }
   if (!newUser.totalDeliveries) {
     newUser.totalDeliveries = 0;
   }

--- a/src/server/db/actions/analytics.ts
+++ b/src/server/db/actions/analytics.ts
@@ -2,17 +2,44 @@
 
 import dbConnect from "../dbConnect";
 import { AnalyticsModel, Analytics } from "../models/analytics";
+import User from "../models/User";
 
-async function updateAnalytics(analytics: Analytics): Promise<Analytics> {
+async function updateAnalytics(): Promise<Analytics> {
   try {
     await dbConnect();
 
-    await AnalyticsModel.deleteMany({});
+    const [result] = await User.aggregate([
+      {
+        $group: {
+          _id: null,
+          totalMonthlyShifts: { $sum: "$monthlyShiftAmount" },
+          totalMonthlyHours: { $sum: "$monthlyHoursVolunteered" },
+          totalYearlyShifts: { $sum: "$yearlyShiftAmount" },
+          totalYearlyHours: { $sum: "$yearlyHoursVolunteered" },
+        },
+      },
+    ]);
 
+    let analytics = await AnalyticsModel.findOne({});
+    if (!analytics) {
+      analytics = new AnalyticsModel();
+    }
+
+    if (result) {
+      analytics.shiftsThisMonth = result.totalMonthlyShifts || 0;
+      analytics.hoursThisMonth = result.totalMonthlyHours || 0;
+      analytics.shiftsThisYear = result.totalYearlyShifts || 0;
+      analytics.hoursThisYear = result.totalYearlyHours || 0;
+    } else {
+      analytics.shiftsThisMonth = 0;
+      analytics.hoursThisMonth = 0;
+      analytics.shiftsThisYear = 0;
+      analytics.hoursThisYear = 0;
+    }
+    
     return await analytics.save();
-  } catch (error) {
-    const err = error as Error;
-    throw new Error(`Error has occurred when creating shift: ${err.message}`);
+  } catch (error: any) {
+    throw new Error(`Error when updating analytics: ${error.message}`);
   }
 }
 

--- a/src/server/db/models/User.ts
+++ b/src/server/db/models/User.ts
@@ -95,7 +95,7 @@ userSchema.methods.populateHours = function (hours: number) {
   return this.save();
 };
 
-userSchema.methods.checkAndResetMonthlyStats = function () {
+userSchema.methods.checkAndResetStats = function () {
   const now = new Date();
   if (!this.lastMonthlyReset) {
     this.lastMonthlyReset = now;
@@ -118,25 +118,25 @@ userSchema.methods.checkAndResetMonthlyStats = function () {
 };
 
 userSchema.methods.populateMonthlyHours = function (hours: number) {
-  this.checkAndResetMonthlyStats();
+  this.checkAndResetStats();
   this.monthlyHoursVolunteered = (this.monthlyHoursVolunteered || 0) + hours;
   return this.save();
 };
 
 userSchema.methods.populateYearlyHours = function (hours: number) {
-  this.checkAndResetMonthlyStats();
+  this.checkAndResetStats();
   this.yearlyHoursVolunteered = (this.yearlyHoursVolunteered || 0) + hours;
   return this.save();
 };
 
 userSchema.methods.populateMonthlyShifts = function () {
-  this.checkAndResetMonthlyStats();
+  this.checkAndResetStats();
   this.monthlyShiftAmount = (this.monthlyShiftAmount || 0) + 1;
   return this.save();
 };
 
 userSchema.methods.populateYearlyShifts = function () {
-  this.checkAndResetMonthlyStats();
+  this.checkAndResetStats();
   this.yearlyShiftAmount = (this.yearlyShiftAmount || 0) + 1;
   return this.save();
 };

--- a/src/server/db/models/analytics.ts
+++ b/src/server/db/models/analytics.ts
@@ -15,6 +15,9 @@ export interface LeaderboardUser {
 export interface Analytics extends Document {
   totalBagelsDelivered: number;
   shiftsThisMonth: number;
+  hoursThisMonth: number;
+  shiftsThisYear: number;
+  hoursThisYear: number;
   shiftsMonthlyAverage: number;
   recentShifts: RecentShift[];
   leaderboardUsersBagelsDelivered: LeaderboardUser[];
@@ -39,6 +42,18 @@ const analyticsSchema: Schema = new Schema({
     default: 0,
   },
   shiftsThisMonth: {
+    type: Number,
+    default: 0,
+  },
+  hoursThisMonth: {
+    type: Number,
+    default: 0,
+  },
+  shiftsThisYear: {
+    type: Number,
+    default: 0,
+  },
+  hoursThisYear: {
     type: Number,
     default: 0,
   },


### PR DESCRIPTION
1. Added `checkAndResetStats` in `src/server/db/models/User.ts` to reset monthly/yearly shifts & hours at the start of each month/year for volunteer analytics.
2. Updated `updateAnalytics` in `src/server/db/actions/analytics.ts` to show monthly & yearly shifts & hours for admin analytics. Since the `Analytics` collection seems to always have only one document, this update method should work fine.