### PR TITLE
Purge old entries when changing date for smoother experience

### DIFF
--- a/src/app/AdminNavView/DailyShiftDashboard/page.tsx
+++ b/src/app/AdminNavView/DailyShiftDashboard/page.tsx
@@ -51,6 +51,7 @@ function DailyShiftDashboardPage() {
     const AddDays = (e: number) => {
         const newDate = new Date(date);
         if (newDate.getDate() - new Date().getDate() !== 7 || e === -1) {
+            setDailyShiftData([])
             newDate.setDate(newDate.getDate() + e);
             setDate(newDate);
         }

--- a/src/app/AdminNavView/WeeklyShiftDashboard/page.tsx
+++ b/src/app/AdminNavView/WeeklyShiftDashboard/page.tsx
@@ -71,6 +71,7 @@ function WeeklyShiftDashboard() {
     const AddDays = (e: number) => {
         const newDate = new Date(date);
         // For weekly view, we move by 7 days (1 week) at a time
+        setWeeklyShiftData([])
         newDate.setDate(newDate.getDate() + e);
         setDate(newDate);
     };


### PR DESCRIPTION
When changing shift data, now it purges old entries until it loads new one