### PR TITLE
fix login redirect bug

### DIFF
--- a/src/lib/authErrorHandler.ts
+++ b/src/lib/authErrorHandler.ts
@@ -10,7 +10,7 @@ export function handleAuthError(error: any, router: AppRouterInstance): boolean 
   if (error instanceof Error) {
     const message = error.message.toLowerCase();
     if (message.includes('unauthorized') || message.includes('forbidden') || message.includes('admin access required')) {
-      router.push('/login');
+      router.push('/Login');
       return true;
     }
   }


### PR DESCRIPTION
Should fix #155 by redirecting to `/Login` instead of `/login`