### PR TITLE
Manual route area input (#225)

### DIFF
--- a/src/app/AdminNavView/RouteCreationPage/page.tsx
+++ b/src/app/AdminNavView/RouteCreationPage/page.tsx
@@ -22,6 +22,7 @@ import { errorToast, successToast } from "@/lib/toastConfig";
 function RouteCreationPage() {
   const [routeName, setRouteName] = useState<string>("");
   const [routeArea, setRouteArea] = useState<{ [key: string]: number }>({});
+  const [manualRouteArea, setManualRouteArea] = useState<string | null>(null);
   const [additionalInfo, setAdditionalInfo] = useState<string>("");
   const [searchText, setSearchText] = useState<string>("");
   const [isAddingLocation, setIsAddingLocation] = useState<boolean>(false);
@@ -130,6 +131,8 @@ function RouteCreationPage() {
 
     routeArea[locToAdd.area] = (routeArea[locToAdd.area] ?? 0) + 1;
 
+    setManualRouteArea(null);
+
     const newIsPickUp = new Map(locationsIsPickUp);
     newIsPickUp.set(
       String(locToAdd._id),
@@ -154,6 +157,8 @@ function RouteCreationPage() {
       delete routeArea[removed.area];
     }
 
+    setManualRouteArea(null);
+
     const newIsPickUp = new Map(locationsIsPickUp);
     newIsPickUp.delete(String(removed._id));
     setLocationsIsPickUp(newIsPickUp);
@@ -171,7 +176,7 @@ function RouteCreationPage() {
 
     const route = {
       routeName: routeName,
-      locationDescription: areas.join(", "),
+      locationDescription: manualRouteArea !== null ? manualRouteArea : areas.join(", "),
       additionalInfo: additionalInfo,
       locations: locs,
     };
@@ -351,7 +356,7 @@ function RouteCreationPage() {
                 <input
                   className="field-input"
                   type="text"
-                  placeholder="Add a Route Name Here"
+                  placeholder="Enter a route name here"
                   value={routeName}
                   onChange={(e) => setRouteName(e.target.value)}
                 />
@@ -361,12 +366,17 @@ function RouteCreationPage() {
                 <input
                   className="field-input"
                   type="text"
-                  value={(() => {
-                    const areas = Object.keys(routeArea);
-                    areas.sort();
-                    return areas.join(", ");
-                  })()}
-                  disabled
+                  placeholder="Enter route area here"
+                  value={
+                    manualRouteArea !== null
+                      ? manualRouteArea
+                      : (() => {
+                          const areas = Object.keys(routeArea);
+                          areas.sort();
+                          return areas.join(", ");
+                        })()
+                  }
+                  onChange={(e) => setManualRouteArea(e.target.value)}
                 />
               </div>
               <div className="field-container">


### PR DESCRIPTION
Fixes #225. Added option for manual route area input on the route creation page:
- Defaults to auto-generated areas from the location list when a location is added or removed
- User can manually type input to override the default auto-generated areas
