### PR TITLE
Fix shift date issue #224

### DIFF
--- a/src/app/AdminNavView/DailyShiftDashboard/page.tsx
+++ b/src/app/AdminNavView/DailyShiftDashboard/page.tsx
@@ -176,6 +176,7 @@ function DailyShiftDashboardPage() {
                             month: "short",
                             day: "numeric",
                             year: "numeric",
+                            timeZone: "UTC",
                         })}
                         onOpenSidebar={() => handleShiftCardClick(shift)}
                     />

--- a/src/app/AdminNavView/WeeklyShiftDashboard/page.tsx
+++ b/src/app/AdminNavView/WeeklyShiftDashboard/page.tsx
@@ -227,6 +227,14 @@ function WeeklyShiftDashboard() {
                     );
                     if (!shiftDate) return null;
 
+                    // ensure shift date is in the date range, not just in the week that overlaps with the date range
+                    const start = normalizeDate(new Date(shift.shiftStartDate));
+                    const end = normalizeDate(new Date(shift.shiftEndDate));
+
+                    if (shiftDate < start || shiftDate > end) {
+                        return null;
+                    }
+
                     if (
                         shift.canceledShifts
                             .map((canceledShift: Date) =>
@@ -265,6 +273,7 @@ function WeeklyShiftDashboard() {
                                 month: "short",
                                 day: "numeric",
                                 year: "numeric",
+                                timeZone: "UTC",
                             })}
                             onOpenSidebar={() =>
                                 handleShiftCardClick(shift, new Date(shiftDate))


### PR DESCRIPTION
Fixes #224  
- Made shift date display use UTC instead of local time. The time is normalized to 00:00:00 in UTC earlier, so converting to local time made the date display as one day earlier (e.g. March 7 midnight in UTC is March 6 7:00 PM in EST)
- Ensured that displayed shifts are actually in the date range. It used to just check if the date range overlapped with the week at all lol (e.g. if the start date is Friday of week 1 and the end date is Friday of week 2, and the recurrence day is Monday, it displayed the shift for both Monday week 1 and Monday week 2, but it should just be Monday week 2)