### PR TITLE
Search Shift Feature + Profile Reloading

### DIFF
--- a/src/app/AdminNavView/DailyShiftDashboard/page.tsx
+++ b/src/app/AdminNavView/DailyShiftDashboard/page.tsx
@@ -176,6 +176,16 @@ function DailyShiftDashboardPage() {
         });
     };
 
+    const searchShiftLocation = (shift: any) => {
+        const query = shiftSearchText.trim().toLowerCase();
+        if (!query) {
+            return true;
+        }
+        const routeName = String(shift["routeName"] ?? "").toLowerCase();
+        const locationDescription = String(shift["locationDescription"] ?? "").toLowerCase();
+        return routeName.includes(query) || locationDescription.includes(query);
+    };
+
     const shiftCardsList = () => {
         return dailyShiftData
             .map((shift: any, shiftIndex) => {
@@ -185,6 +195,7 @@ function DailyShiftDashboardPage() {
                         ? shift.status === "open"
                         : shift.status === "assigned";
                 if (!matchesStatus) return null;
+                if (!searchShiftLocation(shift)) return null;
 
                 return (
                     <ShiftCard
@@ -221,10 +232,11 @@ function DailyShiftDashboardPage() {
 
     // Calculate counts for tabs
     const assignedCount = dailyShiftData.filter(
-        (shift: any) => shift.status === "assigned"
+        (shift: any) =>
+            shift.status === "assigned" && searchShiftLocation(shift)
     ).length;
     const openCount = dailyShiftData.filter(
-        (shift: any) => shift.status === "open"
+        (shift: any) => shift.status === "open" && searchShiftLocation(shift)
     ).length;
 
     return (
@@ -247,7 +259,8 @@ function DailyShiftDashboardPage() {
                                 <input
                                     className="shift-search-input"
                                     type="text"
-                                    placeholder="Search for a shift"
+                                    placeholder="Search for shift by location"
+                                    value={shiftSearchText}
                                     onChange={(e) =>
                                         setShiftSearchText(e.target.value)
                                     }

--- a/src/app/AdminNavView/WeeklyShiftDashboard/page.tsx
+++ b/src/app/AdminNavView/WeeklyShiftDashboard/page.tsx
@@ -256,6 +256,17 @@ function WeeklyShiftDashboard() {
         });
     };
 
+    const searchShiftLocation = (shift: any) => {
+        const query = shiftSearchText.trim().toLowerCase();
+        if (!query) {
+            return true;
+        }
+        const routeName = String(shift["routeName"] ?? "").toLowerCase();
+        const locationDescription = String(shift["locationDescription"] ?? "").toLowerCase();
+        return routeName.includes(query) || locationDescription.includes(query);
+    };
+
+
     // TODO: Can definitely be made more efficient - probably not need
     // to pass entire volunteersPerShift into every Route card
     const routesList = () => {
@@ -266,6 +277,7 @@ function WeeklyShiftDashboard() {
                     ? shift.status === "open"
                     : shift.status === "assigned";
             if (!matchesStatus) return null;
+            if (!searchShiftLocation(shift)) return null;
 
             // Early return if no recurrence dates
             if (!shift["recurrenceDates"]?.length) {
@@ -337,10 +349,11 @@ function WeeklyShiftDashboard() {
 
     // Calculate counts for tabs
     const assignedCount = weeklyShiftData.filter(
-        (shift: any) => shift.status === "assigned"
+        (shift: any) =>
+            shift.status === "assigned" && searchShiftLocation(shift)
     ).length;
     const openCount = weeklyShiftData.filter(
-        (shift: any) => shift.status === "open"
+        (shift: any) => shift.status === "open" && searchShiftLocation(shift)
     ).length;
 
     return (
@@ -363,7 +376,8 @@ function WeeklyShiftDashboard() {
                                 <input
                                     className="shift-search-input"
                                     type="text"
-                                    placeholder="Search for a shift"
+                                    placeholder="Search for shift by location"
+                                    value={shiftSearchText}
                                     onChange={(e) =>
                                         setShiftSearchText(e.target.value)
                                     }

--- a/src/components/AdminSidebar.tsx
+++ b/src/components/AdminSidebar.tsx
@@ -9,6 +9,7 @@ import { TbBrandGoogleAnalytics } from "react-icons/tb";
 import { CiRoute, CiLocationOn } from "react-icons/ci";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faRoute } from "@fortawesome/free-solid-svg-icons";
+import { onAuthStateChanged, type User } from 'firebase/auth';
 import { auth } from '../server/db/firebase';
 import { getUserByEmail } from '../server/db/actions/User';
 import { FaPeopleLine } from "react-icons/fa6";
@@ -41,25 +42,31 @@ const AdminSidebar: React.FC = () => {
   });
 
   useEffect(() => {
-    const fetchUserData = async () => {
+    async function loadProfileFromMongo(email: string) {
       try {
-        const currentUser = auth.currentUser;
-        if (currentUser && currentUser.email) {
-          const mongoUser = await getUserByEmail(currentUser.email);
-          if (mongoUser) {
-            setUserData({
-              firstName: mongoUser.firstName || '',
-              lastName: mongoUser.lastName || '',
-              role: mongoUser.isAdmin ? 'Admin' : 'User'
-            });
-          }
-        }
+        const mongoUser = await getUserByEmail(email);
+        if (!mongoUser) return;
+
+        setUserData({
+          firstName: mongoUser.firstName || '',
+          lastName: mongoUser.lastName || '',
+          role: mongoUser.isAdmin ? 'Admin' : 'User',
+        });
       } catch (error) {
         console.error('Error fetching user data:', error);
       }
-    };
+    }
 
-    fetchUserData();
+    function handleAuthUser(firebaseUser: User | null) {
+      const email = firebaseUser?.email;
+      if (!email) {
+        setUserData({ firstName: '', lastName: '', role: 'Admin' });
+        return;
+      }
+      void loadProfileFromMongo(email);
+    }
+
+    return onAuthStateChanged(auth, handleAuthUser);
   }, []);
 
   const toggleSidebar = () => setIsOpen(!isOpen);

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -6,6 +6,7 @@ import { useState, useEffect } from "react";
 import styles from "./Sidebar.module.css";
 import { FiHome, FiUser } from "react-icons/fi";
 import { TbBrandGoogleAnalytics } from "react-icons/tb";
+import { onAuthStateChanged, type User } from 'firebase/auth';
 import { auth } from '../server/db/firebase';
 import { getUserByEmail } from '../server/db/actions/User';
 import Image from 'next/image';
@@ -36,25 +37,31 @@ const Sidebar: React.FC = () => {
   });
 
   useEffect(() => {
-    const fetchUserData = async () => {
+    async function loadProfileFromMongo(email: string) {
       try {
-        const currentUser = auth.currentUser;
-        if (currentUser && currentUser.email) {
-          const mongoUser = await getUserByEmail(currentUser.email);
-          if (mongoUser) {
-            setUserData({
-              firstName: mongoUser.firstName || '',
-              lastName: mongoUser.lastName || '',
-              role: mongoUser.isAdmin ? 'Admin' : 'Volunteer'
-            });
-          }
-        }
+        const mongoUser = await getUserByEmail(email);
+        if (!mongoUser) return;
+
+        setUserData({
+          firstName: mongoUser.firstName || '',
+          lastName: mongoUser.lastName || '',
+          role: mongoUser.isAdmin ? 'Admin' : 'Volunteer',
+        });
       } catch (error) {
         console.error('Error fetching user data:', error);
       }
-    };
+    }
 
-    fetchUserData();
+    function handleAuthUser(firebaseUser: User | null) {
+      const email = firebaseUser?.email;
+      if (!email) {
+        setUserData({ firstName: '', lastName: '', role: 'Volunteer' });
+        return;
+      }
+      void loadProfileFromMongo(email);
+    }
+
+    return onAuthStateChanged(auth, handleAuthUser);
   }, []);
 
   const toggleSidebar = () => setIsOpen(!isOpen);


### PR DESCRIPTION
• Added search on dashboard: Searches on route and drop-off locations
• Previous implementation used auth.currentUser, which is a one-time snapshot that is often initially null on reload, which is why the name disappeared. Adding onAuthStateChanged registered a listener, when the session is fully restored, Firebase will callback with the code that sets the user data from MongoDB. 
• auth.currentUser is also used in the admin profile pages, so a similar bug occurs, but since there is no user in the session currently, it flashes the sign out page. Once session is loaded, it then reroutes to dashboard - did not fix this yet but can with a similar solution.


