### PR TITLE
Fix location list design 279

### DIFF
--- a/src/app/AdminNavView/LocationPage/page.module.css
+++ b/src/app/AdminNavView/LocationPage/page.module.css
@@ -136,7 +136,7 @@
 }
 
 .locationCard {
-  background-color: var(--background-rgb);
+  background-color: white;
   border: 1px solid #ddd;
   border-radius: 16px;
   border-color: #C6E3FF;

--- a/src/app/AdminNavView/LocationPage/page.tsx
+++ b/src/app/AdminNavView/LocationPage/page.tsx
@@ -271,7 +271,7 @@ function LocationDashboardPage() {
                   <div className={styles.columnHeader}>Address</div>
                   <div className={styles.columnHeader}>Type</div>
                   <div className={styles.columnHeader}>Bags</div>
-                  <div className={styles.columnHeader}>Additional notes</div>
+                  <div className={styles.columnHeader}>Additional Information</div>
                   <div className={styles.columnHeader}></div>
                 </div>
                 <div className={styles.locationList}>


### PR DESCRIPTION
Addresses #279 
- Location list items have white background
- "Additional notes" changed to "Additional Information"
- Ellipsis unchanged - right now the color turns dark when hovered over